### PR TITLE
Like Bug

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,18 +10,30 @@ service cloud.firestore {
     match /loadouts/{loadoutId} {
       allow read: if true;
       allow create: if isSignedIn();
-      allow update, delete: if isSignedIn() && request.auth.uid == resource.data.userId;
+      allow update: if isSignedIn() && (
+        // Allow owner to update their loadout
+        request.auth.uid == resource.data.userId ||
+        // Allow any authenticated user to update likes count
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likes'])
+      );
+      allow delete: if isSignedIn() && request.auth.uid == resource.data.userId;
     }
 
     // Users collection and subcollections
     match /users/{userId} {
       allow read: if true;
-      allow write: if isSignedIn() && request.auth.uid == userId;
+      // Allow updates to totalLikes field by any authenticated user
+      allow update: if isSignedIn() && (
+        request.auth.uid == userId ||
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['totalLikes', 'lastUpdated'])
+      );
+      // Allow other writes only by the user
+      allow create, delete: if isSignedIn() && request.auth.uid == userId;
 
       // Allow access to likes subcollection
       match /likes/{likeId} {
         allow read: if true;
-        allow write: if isSignedIn() && request.auth.uid == userId;
+        allow create, delete: if isSignedIn() && request.auth.uid == userId;
       }
     }
 
@@ -34,7 +46,7 @@ service cloud.firestore {
     // Allow collection group query for likes
     match /{path=**}/likes/{likeId} {
       allow read: if true;
-      allow delete: if isSignedIn();
+      allow create, delete: if isSignedIn() && request.auth.uid == path[1];
     }
   }
 } 


### PR DESCRIPTION
# Fix Like/Unlike Functionality

## Problem
When users liked or unliked a loadout, the entire list of loadouts would temporarily disappear from the UI. This was happening because the `toggleLike` method was calling `loadInitialData()`, which completely reset and reloaded the loadouts list from the server.

## Solution
Implemented optimistic updates for the like/unlike functionality to provide a better user experience:

1. Updated the `toggleLike` method in `LoadoutService` to:
   - Update the local state immediately before the server transaction
   - Remove the unnecessary `loadInitialData()` call
   - Maintain list state during the like/unlike operation

### Implementation Details
- Added local state update using `loadoutStateService`:
  ```typescript
  const currentLoadouts = this.loadoutStateService.getCurrentLoadouts();
  const updatedLoadouts = currentLoadouts.map(loadout => {
    if (loadout.id === loadoutId) {
      return {
        ...loadout,
        likes: (loadout.likes || 0) + (hasLiked ? -1 : 1)
      };
    }
    return loadout;
  });
  this.loadoutStateService.updateLoadouts(updatedLoadouts);
  ```

- The Firebase transaction remains unchanged, ensuring data consistency on the server:
  - Updates the like count on the loadout document
  - Creates/deletes the like document in the user's subcollection
  - Updates the owner's total likes count

### Security
- Updated Firestore security rules to properly handle all operations involved in toggling likes:
  - Allow authenticated users to update only the `likes` field on loadouts
  - Allow users to create/delete likes in their own subcollection
  - Allow updating the `totalLikes` field on the owner's user document

## Testing
- Verified that the loadouts list remains visible during like/unlike operations
- Confirmed that like counts update immediately in the UI
- Validated that like state persists after page refresh
- Tested security rules to ensure proper access control